### PR TITLE
Fix/scrape_articles.py

### DIFF
--- a/classification_machine/management/commands/scrape_articles.py
+++ b/classification_machine/management/commands/scrape_articles.py
@@ -11,6 +11,9 @@ from django.utils import timezone
 from urllib.parse import urlencode
 import time
 
+import logging
+logger = logging.getLogger(__name__)
+
 
 class Command(BaseCommand):
     help = 'Scraping article contents from Gunosy.'
@@ -55,6 +58,6 @@ class Command(BaseCommand):
                             url=article_url,
                             updated_at=scraper.get_article_updated_at())
                 except Exception as e:
-                    print(type(e).__name__, e)
+                    logger.warning(type(e).__name__, e)
 
                 time.sleep(1)


### PR DESCRIPTION
- fix scrape_articles.py
  - urlの組み立てに`urllib.parse.urlencode`を使用
  - total_pagesの定数化
  - category_page_urlsを普通のリストとして定義
  - エラーハンドリング